### PR TITLE
funni vestine recipe. Intended to be annoying, esp for ghetto chemming

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -81,7 +81,7 @@
       amount: 1
     Sulfur:
       amount: 1
-    Oxygen: 
+    Oxygen:
       amount: 2
   products:
     SulfuricAcid: 3
@@ -501,3 +501,20 @@
       amount: 1
   products:
     Tazinide: 1
+
+- type: reaction
+  id: Vestine
+  impact: High
+  reactants: #should be complicated to make without proper chem tools, intended for ghetto chem
+    Siderlac:
+      amount: 1 #forced to interact with botany
+    Diphenylmethylamine:
+      amount: 1 #long crafting chain
+    Whiskey:
+      amount: 3 # interaction with bar/alcohol obtaining mech
+    Razorium:
+      amount: 20
+      catalyst: True # fun raz to deal with, depending on vestine usecase this is either an added bonus or something to deal with
+      #Initially was bic 2 punc 3 but that just makes raz. If you can fix that go ahead.
+  products:
+    Vestine: 3

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -561,7 +561,7 @@
   id: Opporozidone
   minTemp: 400 #Maybe if a method of reducing reagent temp exists one day, this could be -50
   reactants:
-    Cognizine: 
+    Cognizine:
       amount: 1
     Plasma:
       amount: 2


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Adds a recipe for vestine - designed to be annoying for ghetto chemming
1 Siderlac
1 Diphenylmethylamine
3 Whiskey
20 Razorium (catalyst)

## Why / Balance
So non-traitor prisoners can use vestine requiring chems in escape attempts, if they are willing to put in the time for it.
Siderlac - requires either working in botany and 'borrowing' some product or stealing/begging it
Diphenylmethylamine - long chain of rquired chems, esp annoying without chemmaster
Raz catalyst - leaves sharp bits in your vestine, this is either nice if your making stuff that you arent taking or a major downside for like. Stimulants

## Technical details
Recipe added to bottom of chemical recipes 

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

[X] this PR does not require an ingame showcase 


