### PR TITLE
funni vestine recipe. Intended to be annoying, esp for ghetto chemming

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/SP14/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/SP14/chemicals.yml
@@ -1,0 +1,17 @@
+﻿- type: reaction
+  id: Vestine
+  impact: High
+  priority: 10
+  reactants: #should be complicated to make without proper chem tools, intended for ghetto chem
+    Siderlac:
+      amount: 1 #forced to interact with botany
+    Diphenylmethylamine:
+      amount: 1 #long crafting chain
+    Whiskey:
+      amount: 3 # interaction with bar/alcohol obtaining mechanism
+    Bicaridine:
+      amount: 2
+    Puncturase: # chance of fun raz to deal with, depending on vestine usecase this is either an added bonus or something to deal with
+      amount: 3 # basically chem skillcheck
+  products:
+    Vestine: 3

--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -81,7 +81,7 @@
       amount: 1
     Sulfur:
       amount: 1
-    Oxygen: 
+    Oxygen:
       amount: 2
   products:
     SulfuricAcid: 3
@@ -501,3 +501,20 @@
       amount: 1
   products:
     Tazinide: 1
+
+- type: reaction
+  id: Vestine
+  impact: High
+  reactants: #should be complicated to make without proper chem tools, intended for ghetto chem
+    Siderlac:
+      amount: 1 #forced to interact with botany
+    Diphenylmethylamine:
+      amount: 1 #long crafting chain
+    Whiskey:
+      amount: 3 # interaction with bar/alcohol obtaining mech
+    Razorium:
+      amount: 20
+      catalyst: True # fun raz to deal with, depending on vestine usecase this is either an added bonus or something to deal with
+      #Initially was bic 2 punc 3 but that just makes raz. If you can fix that go ahead.
+  products:
+    Vestine: 3

--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -505,16 +505,17 @@
 - type: reaction
   id: Vestine
   impact: High
+  priority: 10
   reactants: #should be complicated to make without proper chem tools, intended for ghetto chem
     Siderlac:
       amount: 1 #forced to interact with botany
     Diphenylmethylamine:
       amount: 1 #long crafting chain
     Whiskey:
-      amount: 3 # interaction with bar/alcohol obtaining mech
-    Razorium:
-      amount: 20
-      catalyst: True # fun raz to deal with, depending on vestine usecase this is either an added bonus or something to deal with
-      #Initially was bic 2 punc 3 but that just makes raz. If you can fix that go ahead.
+      amount: 3 # interaction with bar/alcohol obtaining mechanism
+    Bicaridine:
+      amount: 2
+    Puncturase: # chance of fun raz to deal with, depending on vestine usecase this is either an added bonus or something to deal with
+      amount: 3 # basically chem skillcheck
   products:
     Vestine: 3

--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -501,21 +501,3 @@
       amount: 1
   products:
     Tazinide: 1
-
-- type: reaction
-  id: Vestine
-  impact: High
-  priority: 10
-  reactants: #should be complicated to make without proper chem tools, intended for ghetto chem
-    Siderlac:
-      amount: 1 #forced to interact with botany
-    Diphenylmethylamine:
-      amount: 1 #long crafting chain
-    Whiskey:
-      amount: 3 # interaction with bar/alcohol obtaining mechanism
-    Bicaridine:
-      amount: 2
-    Puncturase: # chance of fun raz to deal with, depending on vestine usecase this is either an added bonus or something to deal with
-      amount: 3 # basically chem skillcheck
-  products:
-    Vestine: 3

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -561,7 +561,7 @@
   id: Opporozidone
   minTemp: 400 #Maybe if a method of reducing reagent temp exists one day, this could be -50
   reactants:
-    Cognizine: 
+    Cognizine:
       amount: 1
     Plasma:
       amount: 2


### PR DESCRIPTION
## About the PR
Adds a recipe for vestine - designed to be annoying for ghetto chemming
1 Siderlac
1 Diphenylmethylamine
3 Whiskey
2 bicardine
3 puncturase

## Why / Balance
So non-traitor prisoners can use vestine requiring chems in escape attempts, if they are willing to put in the time for it.
Siderlac - requires either working in botany and 'borrowing' some product or stealing/begging it
Diphenylmethylamine - long chain of rquired chems, esp annoying without chemmaster
2 brutes - chem skillcheck to avoid raz, or bonus if making something for other ppl. 

## Technical details
Recipe added to bottom of chemical recipes